### PR TITLE
PHPCSのチェック用のプルリクエストです

### DIFF
--- a/php_demo_sample/ruleset.xml
+++ b/php_demo_sample/ruleset.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Standard">
+  <description>My custom coding standard</description>
+  <rule ref="PEAR">
+    <exclude name="PEAR.Commenting.ClassComment"/>
+    <exclude name="PEAR.Commenting.FileComment"/>
+    <exclude name="PEAR.Commenting.FunctionComment"/>
+    <exclude name="PEAR.Commenting.InlineComment"/>
+    <exclude name="PEAR.Classes.ClassDeclaration"/>
+    <exclude name="Generic.Files.LineEndings"/>
+  </rule>
+
+  <rule ref="PEAR.WhiteSpace.ScopeIndent">
+    <properties>
+      <property name="indent" value="2"/>
+    </properties>
+  </rule>
+
+</ruleset>

--- a/php_demo_sample/style_check.php
+++ b/php_demo_sample/style_check.php
@@ -10,14 +10,14 @@ namespace PhpDemoSample;
  */
 class StyelCheck
 {
-  /** 
-   * Some comment here!
-   * 
-   * @return string Return message "Sample!"
-   */
-  public function sample()
-  {
-    // comment here! 
-    return response('Sample');
-  }
+    /**
+     * Some comment here!
+     *
+     * @return string Return message "Sample!"
+     */
+    public function sample()
+    {
+        // comment here!
+        return response('Sample');
+    }
 }

--- a/php_demo_sample/style_check.php
+++ b/php_demo_sample/style_check.php
@@ -1,4 +1,13 @@
 <?php
+namespace PhpDemoSample;
+
+/**
+ * StyelCheck model Doc Comment
+ *
+ * @category Class
+ * @package  MyPackage
+ * @author   Its Me <username@example.com>
+ */
 class StyelCheck
 {
   /** 
@@ -6,7 +15,7 @@ class StyelCheck
    * 
    * @return string Return message "Sample!"
    */
-  function sample()
+  public function sample()
   {
     // comment here! 
     return response('Sample');

--- a/php_demo_sample/style_check.php
+++ b/php_demo_sample/style_check.php
@@ -1,0 +1,14 @@
+<?php
+class StyelCheck
+{
+  /** 
+   * Some comment here!
+   * 
+   * @return string Return message "Sample!"
+   */
+  function sample()
+  {
+    // comment here! 
+    return response('Sample');
+  }
+}

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,6 @@
+linter:
+  code_sniffer:
+    dir: php_demo_sample/
+    standard: php_demo_sample/ruleset.xml
+    extensions: php,inc,lib
+    encoding: utf-8


### PR DESCRIPTION
# このプルリクエストについて

以下を提示するサンプルになります。

- SiderのPHP Code Snifferの解析例の提示
- PHP Code Snifferに対し、独自ルールを適用するための例
 - 個別の設定ファイル (ruleset.xml といった、専用のフォーマットでのXMLを作成）
 - sideci.yml に登録して、解析時にruleset.xml を読み込むようにする

## 初回コミットのPHP Code Snifferの解析例

commit: 00a2232 の時点では、Siderはコマンドラインで**PSR2**を標準スタイルとして指定して結果を出力します。

* https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

```code:bash

$ phpcs --standard=PSR2 style_check.php

FILE: /xxxxx/php_conf_demo/php_demo_sample/style_check.php
----------------------------------------------------------------------------------------------------
FOUND 9 ERRORS AFFECTING 8 LINES
----------------------------------------------------------------------------------------------------
  2 | ERROR | [ ] Each class must be in a namespace of at least one level (a top-level vendor name)
  4 | ERROR | [x] Whitespace found at end of line
  6 | ERROR | [x] Whitespace found at end of line
  9 | ERROR | [x] Line indented incorrectly; expected 4 spaces, found 2
  9 | ERROR | [ ] Visibility must be declared on method "sample"
 10 | ERROR | [x] Line indented incorrectly; expected at least 4 spaces, found 2
 11 | ERROR | [x] Whitespace found at end of line
 12 | ERROR | [x] Line indented incorrectly; expected at least 8 spaces, found 4
 13 | ERROR | [x] Line indented incorrectly; expected 4 spaces, found 2
----------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------

Time: 81ms; Memory: 6Mb

```

![as-is](https://user-images.githubusercontent.com/122621/51486916-455dc400-1de5-11e9-97f5-cb628a0a4b02.png)

## 2回目のコミット / 修正

解析結果のうち、上記のコマンドラインツールでの結果でも出た通り、``[  ]`` になっているものは手動でソースを修正する必要があります。もしくは、Sider側でCloseをするといったことで対応になります。
今回は、ドキュメントのコメントを付ける、"public" をつけて関数をパブリックで呼び出せるように明示しました。

この 4afd1a9 を受けて、Sider側も３つがFixされています。

![fixed-4afd1a9](https://user-images.githubusercontent.com/122621/51497911-f5dcbf80-1e07-11e9-852b-e12eb0a9c45f.png)

## 3回目のコミット / phpcbf を使って修正

``PHPCBF CAN FIX THE 7 MARKED`` のメッセージの通り、``[x]`` マークのついたものは、phpcbf というコマンドラインツールを使うと、自動で修正されます。

```code:bash
phpcbf --standard=PSR2 style_check.php

PHPCBF RESULT SUMMARY
------------------------------------------------------------------------------------
FILE                                                                FIXED  REMAINING
------------------------------------------------------------------------------------
/xxx/php_conf_demo/php_demo_sample/style_check.php     7      0
------------------------------------------------------------------------------------
A TOTAL OF 7 ERRORS WERE FIXED IN 1 FILE
------------------------------------------------------------------------------------

Time: 44ms; Memory: 6Mb
```

こちらの結果を dd94bc1 としてコミット。
この dd94bc1 を受けて、Sider側で全てFixedになりました。

![fixed-dd94bc1](https://user-images.githubusercontent.com/122621/51498715-f1fe6c80-1e0a-11e9-986a-797193347208.png)

## 4回目のコミット / あらためてカスタマイズした設定を適用する

5fac810 にて、「インデントを**2スペースにカスタマイズ**」した設定を登録しました。
また、Siderでの解析の際に、PSR2に加えて、カスタマイズしたルール (ruleset.xml) も利用するようにしました。

Sider側の解析ツールの実行ログでは、phpcs に対し、オプション設定が適用されています。
この結果、登録したPHPは4スペースインデントなので、再度エラーとなっています。

```code:bash
# phpcs3 --report=json --report-json=/xxxxxx/output.txt  \
  --standard=php_demo_sample/ruleset.xml --extensions=php,inc,lib \
  --encoding=utf-8 php_demo_sample/
```

![failed-again](https://user-images.githubusercontent.com/122621/51501556-b6b56b00-1e15-11e9-88e3-5ac9b9390e27.png)